### PR TITLE
【发现个crash】点击第一个【按钮下载】--》【按钮删除】--》【按钮清除】 程序崩溃

### DIFF
--- a/HSDownloadManager/HSDownloadManager.m
+++ b/HSDownloadManager/HSDownloadManager.m
@@ -310,7 +310,9 @@ static HSDownloadManager *_downloadManager;
     NSUInteger expectedSize = sessionModel.totalLength;
     CGFloat progress = 1.0 * receivedSize / expectedSize;
 
-    sessionModel.progressBlock(receivedSize, expectedSize, progress);
+    if (sessionModel) {
+        sessionModel.progressBlock(receivedSize, expectedSize, progress);
+    }
 }
 
 /**


### PR DESCRIPTION
原因：是SessionModel对象被释放-》nil
解决方案 ：对SessionModel对象进行非空处理
